### PR TITLE
spara genomförd order på server

### DIFF
--- a/orders.json
+++ b/orders.json
@@ -1,0 +1,7 @@
+[
+  {
+    "amount": 90,
+    "customerId": "cus_KI8zLOYHyv8fqW",
+    "customerEmail": "axelsundin@hotmail.com"
+  }
+]

--- a/public/checkout.js
+++ b/public/checkout.js
@@ -27,11 +27,9 @@ if (cart == null) {
   Object.entries(cart).map((e) => {
     totalPrice = totalPrice + e[1].price_data.unit_amount * e[1].quantity;
     console.log(e);
-
     const productImg = document.createElement("img");
-    productImg.src = e[1].images
+    productImg.src = e[1].images;
     containerDiv.appendChild(productImg);
-    
     const productName = document.createElement("h3");
     productName.innerText = e[0];
     const productDescription = document.createElement("p");
@@ -49,11 +47,9 @@ if (cart == null) {
     containerDiv.appendChild(productDescription);
     containerDiv.appendChild(productQuantity);
     containerDiv.appendChild(separationLine);
-    console.log(e)
-    delete e[1].images
-
+    console.log(e);
+    delete e[1].images;
   });
-  
 
   productsTotalPrice.innerText =
     "Summa: " +
@@ -72,7 +68,7 @@ const checkout = async () => {
     if (Object.keys(cart).length == 0) {
       throw new Error("No products added");
     }
-    
+
     const response = await fetch("/api/session/new", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -81,6 +77,8 @@ const checkout = async () => {
       }),
     });
     const { id } = await response.json();
+    console.log(id);
+    localStorage.setItem("session", id);
     stripe.redirectToCheckout({ sessionId: id });
   } catch (err) {
     console.log(err);

--- a/public/index.js
+++ b/public/index.js
@@ -97,4 +97,44 @@ function renderProducts() {
   });
 }
 
-renderProducts();
+const verify = async () => {
+  try {
+    const sessionId = localStorage.getItem("session");
+    if (!sessionId) {
+      throw new Error("No session id to verify");
+    }
+
+    const response = await fetch("/api/session/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+      }),
+    });
+    const { paid } = await response.json();
+    return paid;
+  } catch (err) {
+    console.log(err);
+    return false;
+  }
+};
+
+async function main() {
+  renderProducts();
+  const isVerified = await verify();
+  console.log(isVerified);
+
+  if (localStorage.getItem("session")) {
+    if (isVerified) {
+      alert("Tack för ditt köp");
+      localStorage.removeItem("cart");
+    } else {
+      alert(
+        "Köp avbrutet. Sessionen tas bort men produkterna är kvar i localstorage"
+      );
+    }
+    localStorage.removeItem("session");
+  }
+}
+
+main();

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ env.config(".env");
 const secretKey = process.env.STRIPE_SECRET_KEY;
 const stripe = require("stripe")(secretKey);
 const app = express();
+const fs = require("fs");
 
 app.use(express.static("public"));
 app.use("/api", express.json());
@@ -13,10 +14,49 @@ app.post("/api/session/new", async (req, res) => {
     payment_method_types: ["card"],
     line_items: req.body.line_items,
     mode: "payment",
-    success_url: "http://localhost:3000/checkout_success.html",
-    cancel_url: "http://localhost:3000/index.html",
+    success_url: "http://localhost:3000/",
+    cancel_url: "http://localhost:3000/",
   });
   res.status(200).json({ id: session.id });
+});
+
+app.post("/api/session/verify", async (req, res) => {
+  const sessionId = req.body.sessionId;
+  const session = await stripe.checkout.sessions.retrieve(sessionId);
+
+  if (session.payment_status == "paid") {
+    //Spara
+    const key = session.payment_intent;
+
+    /* const paymentIntent = await stripe.paymentIntents.retrieve(
+      session.payment_intent
+    ); */
+
+    let raw = fs.readFileSync("orders.json");
+    let data = JSON.parse(raw);
+    //console.log(data);
+
+    if (!data[key]) {
+      data[key] = {
+        amount: session.amount_total / 100,
+        customerId: session.customer,
+        customerEmail: session.customer_details.email,
+        //metadata: session.metadata,
+      };
+      data.push(data[key]);
+      fs.writeFileSync("orders.json", JSON.stringify(data));
+    }
+    res.status(200).json({ paid: true });
+  } else {
+    res.status(200).json({ paid: false });
+  }
+  //console.log(session);
+});
+
+app.get("/api/admin/purchases", async (req, res) => {
+  let raw = fs.readFileSync("orders.json");
+  let data = JSON.parse(raw);
+  res.status(200).json(data);
 });
 
 app.listen(3000, () => {


### PR DESCRIPTION
-Påbörjad betalning skapar en stripe-session som sparar sessions id:t i localstorage
-För att se om en betalning är genomförd eller avbruten körs funktionen verify som skickar sessions id:t till endpointen  /api/session/verify.
-På servern kontrolleras det om sessionens payment status är paid. Om ja sparas ordern i en json fil och returnerar true till klienten. Om nej returneras false
-Om true: skrivs "tack för ditt köp" ut hos klienten och cart och session raderas från local storage
-Om false: skrivs "köp avbrutet..." ut hos klienten. Cart finns kvar i localstorage så kunden kan försöka betala igen. Stripe-session raderas från local storage, för en ny påbörjas när kunden försöker betala igen.