### PR TITLE
Spara order utan localstorage

### DIFF
--- a/orders.json
+++ b/orders.json
@@ -1,7 +1,1 @@
-[
-  {
-    "amount": 90,
-    "customerId": "cus_KI8zLOYHyv8fqW",
-    "customerEmail": "axelsundin@hotmail.com"
-  }
-]
+[{"sessionId":"cs_test_a1GC6S794alSL1I4W4ujeJrgSHvzx2kDGjVoBhxUd0EGa678zOQIKitkCu","customerId":"cus_KJHVgrEN2cr3N4","date":"2021-09-28T13:35:16.337Z","customerEmail":"axelsundin@hotmail.com","totalPrice":450,"products":[{"id":"li_1JeewDBqFnPYjqEI022vnIjT","object":"item","amount_subtotal":45000,"amount_total":45000,"currency":"sek","description":"En produktbeskrivning","price":{"id":"price_1JeewDBqFnPYjqEIcs9KtF6o","object":"price","active":false,"billing_scheme":"per_unit","created":1632830253,"currency":"sek","livemode":false,"lookup_key":null,"metadata":{},"nickname":null,"product":"prod_KJHVmRVH2soc8c","recurring":null,"tax_behavior":"unspecified","tiers_mode":null,"transform_quantity":null,"type":"one_time","unit_amount":9000,"unit_amount_decimal":"9000"},"quantity":5}],"key":"pi_3JeewDBqFnPYjqEI1cFwE4k5"}]

--- a/public/checkout.js
+++ b/public/checkout.js
@@ -77,8 +77,6 @@ const checkout = async () => {
       }),
     });
     const { id } = await response.json();
-    console.log(id);
-    localStorage.setItem("session", id);
     stripe.redirectToCheckout({ sessionId: id });
   } catch (err) {
     console.log(err);

--- a/public/checkout_success.html
+++ b/public/checkout_success.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" href="style.css" />
+    <script defer src="checkout_success.js"></script>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/public/checkout_success.js
+++ b/public/checkout_success.js
@@ -1,0 +1,18 @@
+//session id from url
+let url = new URL(window.location);
+let params = new URLSearchParams(url.search);
+let sessionId = params.get("session_id");
+
+const verify = async () => {
+  try {
+    const response = await fetch("/api/session/verify/" + sessionId, {
+      method: "POST",
+    });
+    const isVerified = await response.json();
+    console.log(isVerified);
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+verify();

--- a/public/index.js
+++ b/public/index.js
@@ -97,7 +97,7 @@ function renderProducts() {
   });
 }
 
-const verify = async () => {
+/* const verify = async () => {
   try {
     const sessionId = localStorage.getItem("session");
     if (!sessionId) {
@@ -138,3 +138,6 @@ async function main() {
 }
 
 main();
+ */
+
+renderProducts();


### PR DESCRIPTION
-Success url går till en ny sida där session id sparas i url'en istället för localstorage
-Ändrat på verify-endpointen så ordern fortfarande sparas